### PR TITLE
fix issue action executed after compensation triggered

### DIFF
--- a/saga.go
+++ b/saga.go
@@ -60,7 +60,7 @@ func (s *Saga) startSaga() {
 // ExecSub executes a sub-transaction for given subTxID(which define in SEC initialize) and arguments.
 // it returns current Saga.
 func (s *Saga) ExecSub(subTxID string, args ...interface{}) *Saga {
-	if s.abortStatus {
+	if s.IsAborted() {
 		return s
 	}
 
@@ -100,7 +100,7 @@ func (s *Saga) ExecSub(subTxID string, args ...interface{}) *Saga {
 }
 
 // EndSaga finishes a Saga's execution.
-func (s *Saga) EndSaga() {
+func (s *Saga) EndSaga() *Saga {
 	log := &Log{
 		Type: SagaEnd,
 		Time: time.Now(),
@@ -113,6 +113,13 @@ func (s *Saga) EndSaga() {
 	if err != nil {
 		panic("Clean up topic failure")
 	}
+
+	return s
+}
+
+// IsAborted return status if saga is aborted or not
+func (s *Saga) IsAborted() bool {
+	return s.abortStatus
 }
 
 // Abort stop and compensate to rollback to start situation.


### PR DESCRIPTION
Re-PR this issue. Need review by maintainer.

## What I fixed

- Order & payment logic still executed even though **compensatePurchaseItem** had been executed. This means order & payment logic shouldn't be executed.

```go
saga.AddSubTxDef(labelPurchaseItem, purchaseItemFailed, compensatePurchaseItem).
    AddSubTxDef(labelOrder, orderSuccess, compensateOrder).
    AddSubTxDef(labelPayment, paymentSuccess, compensatePayment)

ctx := context.Background()
property := &orderProperty{}
saga.StartSaga(ctx, sagaTopicID).
    ExecSub(labelPurchaseItem, property, input.Item).
    ExecSub(labelOrder, property, input.Item, input.Price).
    ExecSub(labelPayment, property, input.PaymentMethod, input.Price).
    EndSaga()
```

- Add `IsAborted()` function to detect whether saga is complete or aborted. 

Example:

```go
sagaInstance := saga.StartSaga(ctx, sagaTopicID).
    ExecSub(labelPurchaseItem, property, input.Item).
    ExecSub(labelOrder, property, input.Item, input.Price).
    ExecSub(labelPayment, property, input.PaymentMethod, input.Price).
    EndSaga()

if sagaInstance.IsAborted() {
    // do something if saga is aborted
}
```